### PR TITLE
Don't use the libspf caching layer.

### DIFF
--- a/spf2.go
+++ b/spf2.go
@@ -41,7 +41,7 @@ type clientImpl struct {
 // NewClient creates a new SPF client.
 func NewClient() Client {
 	client := new(clientImpl)
-	client.s = C.SPF_server_new(C.SPF_DNS_CACHE, 0)
+	client.s = C.SPF_server_new(C.SPF_DNS_RESOLV, 0)
 	return client
 }
 


### PR DESCRIPTION
Caching should be left up to the (local) resolver, not to random libraries.
What's especially frustrating is that it also caches errors for abitrary
amounts of time